### PR TITLE
Refs [TASK] [37491] Xử lý khi người dùng click chọn collection

### DIFF
--- a/app/src/main/java/com/sun/unsplash03/data/model/Collection.kt
+++ b/app/src/main/java/com/sun/unsplash03/data/model/Collection.kt
@@ -1,10 +1,13 @@
 package com.sun.unsplash03.data.model
 
+import android.os.Parcelable
 import com.google.gson.annotations.SerializedName
+import kotlinx.parcelize.Parcelize
 
+@Parcelize
 data class Collection(
     val id: String = "",
     val title: String = "",
     @SerializedName("cover_photo")
     val coverPhoto: CoverPhoto
-)
+) : Parcelable

--- a/app/src/main/java/com/sun/unsplash03/data/model/CoverPhoto.kt
+++ b/app/src/main/java/com/sun/unsplash03/data/model/CoverPhoto.kt
@@ -1,5 +1,9 @@
 package com.sun.unsplash03.data.model
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
 data class CoverPhoto(
     val urls: PhotoUrls
-)
+) : Parcelable

--- a/app/src/main/java/com/sun/unsplash03/data/repository/PhotoRepository.kt
+++ b/app/src/main/java/com/sun/unsplash03/data/repository/PhotoRepository.kt
@@ -6,5 +6,11 @@ import com.sun.unsplash03.utils.scheduler.DataResult
 
 interface PhotoRepository {
     suspend fun getPhotos(page: Int?): DataResult<MutableList<Photo>>
+
     suspend fun getCollections(page: Int?): DataResult<MutableList<Collection>>
+
+    suspend fun getCollectionPhotos(
+        collectionId: String,
+        page: Int?
+    ): DataResult<MutableList<Photo>>
 }

--- a/app/src/main/java/com/sun/unsplash03/data/repository/PhotoRepositoryImpl.kt
+++ b/app/src/main/java/com/sun/unsplash03/data/repository/PhotoRepositoryImpl.kt
@@ -6,11 +6,13 @@ import com.sun.unsplash03.utils.base.BaseRepository
 class PhotoRepositoryImpl(private val remote: PhotoDataSource.Remote) : PhotoRepository,
     BaseRepository() {
 
-    override suspend fun getPhotos(page: Int?) = withResultContext {
-        remote.getPhotos(page)
-    }
+    override suspend fun getPhotos(page: Int?) = withResultContext { remote.getPhotos(page) }
 
-    override suspend fun getCollections(page: Int?) = withResultContext {
-        remote.getCollections(page)
-    }
+    override suspend fun getCollections(page: Int?) =
+        withResultContext { remote.getCollections(page) }
+
+    override suspend fun getCollectionPhotos(
+        collectionId: String,
+        page: Int?
+    ) = withResultContext { remote.getCollectionPhotos(collectionId, page) }
 }

--- a/app/src/main/java/com/sun/unsplash03/data/source/PhotoDataSource.kt
+++ b/app/src/main/java/com/sun/unsplash03/data/source/PhotoDataSource.kt
@@ -9,6 +9,9 @@ interface PhotoDataSource {
 
     interface Remote {
         suspend fun getPhotos(page: Int?): MutableList<Photo>
+
         suspend fun getCollections(page: Int?): MutableList<Collection>
+
+        suspend fun getCollectionPhotos(collectionId: String, page: Int?): MutableList<Photo>
     }
 }

--- a/app/src/main/java/com/sun/unsplash03/data/source/remote/ApiService.kt
+++ b/app/src/main/java/com/sun/unsplash03/data/source/remote/ApiService.kt
@@ -4,6 +4,7 @@ import com.sun.unsplash03.data.model.Collection
 import com.sun.unsplash03.data.model.Photo
 import com.sun.unsplash03.utils.Constants
 import retrofit2.http.GET
+import retrofit2.http.Path
 import retrofit2.http.Query
 
 interface ApiService {
@@ -18,4 +19,11 @@ interface ApiService {
         @Query("page") page: Int? = null,
         @Query("per_page") perPage: Int = Constants.PER_PAGE_DEFAULT
     ): MutableList<Collection>
+
+    @GET("/collections/{id}/photos")
+    suspend fun getCollectionPhotos(
+        @Path("id") collectionId: String,
+        @Query("page") page: Int? = null,
+        @Query("per_page") perPage: Int = Constants.PER_PAGE_DEFAULT
+    ): MutableList<Photo>
 }

--- a/app/src/main/java/com/sun/unsplash03/data/source/remote/PhotoRemoteImpl.kt
+++ b/app/src/main/java/com/sun/unsplash03/data/source/remote/PhotoRemoteImpl.kt
@@ -7,4 +7,7 @@ class PhotoRemoteImpl(private val apiService: ApiService) : PhotoDataSource.Remo
     override suspend fun getPhotos(page: Int?) = apiService.getPhotos(page)
 
     override suspend fun getCollections(page: Int?) = apiService.getCollections(page)
+
+    override suspend fun getCollectionPhotos(collectionId: String, page: Int?) =
+        apiService.getCollectionPhotos(collectionId, page)
 }

--- a/app/src/main/java/com/sun/unsplash03/di/ViewModelModule.kt
+++ b/app/src/main/java/com/sun/unsplash03/di/ViewModelModule.kt
@@ -1,6 +1,7 @@
 package com.sun.unsplash03.di
 
 import com.sun.unsplash03.screen.collection.CollectionViewModel
+import com.sun.unsplash03.screen.collection_photo.CollectionPhotoViewModel
 import com.sun.unsplash03.screen.detail.DetailViewModel
 import com.sun.unsplash03.screen.favorite.FavoriteViewModel
 import com.sun.unsplash03.screen.home.HomeViewModel
@@ -16,4 +17,5 @@ val viewModelModule = module {
     viewModel { CollectionViewModel(get()) }
     viewModel { FavoriteViewModel() }
     viewModel { DetailViewModel() }
+    viewModel { CollectionPhotoViewModel(get()) }
 }

--- a/app/src/main/java/com/sun/unsplash03/screen/collection/CollectionFragment.kt
+++ b/app/src/main/java/com/sun/unsplash03/screen/collection/CollectionFragment.kt
@@ -2,10 +2,13 @@ package com.sun.unsplash03.screen.collection
 
 import android.view.LayoutInflater
 import androidx.lifecycle.Observer
+import com.sun.unsplash03.R
 import com.sun.unsplash03.data.model.Collection
 import com.sun.unsplash03.databinding.FragmentCollectionBinding
 import com.sun.unsplash03.screen.collection.adapter.CollectionAdapter
+import com.sun.unsplash03.screen.collection_photo.CollectionPhotoFragment
 import com.sun.unsplash03.utils.base.BaseFragment
+import com.sun.unsplash03.utils.ext.replaceFragment
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class CollectionFragment : BaseFragment<FragmentCollectionBinding, CollectionViewModel>() {
@@ -38,6 +41,7 @@ class CollectionFragment : BaseFragment<FragmentCollectionBinding, CollectionVie
     }
 
     private fun clickItemCollection(collection: Collection) {
+        replaceFragment(R.id.containerFrameLayout, CollectionPhotoFragment.newInstance(collection))
     }
 
     companion object {

--- a/app/src/main/java/com/sun/unsplash03/screen/collection_photo/CollectionPhotoFragment.kt
+++ b/app/src/main/java/com/sun/unsplash03/screen/collection_photo/CollectionPhotoFragment.kt
@@ -1,0 +1,70 @@
+package com.sun.unsplash03.screen.collection_photo
+
+import android.view.LayoutInflater
+import androidx.core.os.bundleOf
+import androidx.recyclerview.widget.StaggeredGridLayoutManager
+import com.sun.unsplash03.R
+import com.sun.unsplash03.data.model.Collection
+import com.sun.unsplash03.data.model.Photo
+import com.sun.unsplash03.databinding.FragmentCollectionPhotoBinding
+import com.sun.unsplash03.screen.detail.DetailFragment
+import com.sun.unsplash03.screen.photo.adapter.PhotoAdapter
+import com.sun.unsplash03.utils.base.BaseFragment
+import com.sun.unsplash03.utils.ext.replaceFragment
+import org.koin.androidx.viewmodel.ext.android.viewModel
+
+class CollectionPhotoFragment :
+    BaseFragment<FragmentCollectionPhotoBinding, CollectionPhotoViewModel>() {
+
+    private val photoAdapter by lazy { PhotoAdapter(::clickPhotoItem) }
+
+    override val viewModel: CollectionPhotoViewModel by viewModel()
+
+    override fun inflateViewBinding(inflater: LayoutInflater) =
+        FragmentCollectionPhotoBinding.inflate(inflater)
+
+    override fun setUpView() {
+        viewBinding.run {
+            lifecycleOwner = this@CollectionPhotoFragment.viewLifecycleOwner
+            viewModel = this@CollectionPhotoFragment.viewModel
+            adapter = photoAdapter
+            toolbarCollectionPhoto.setNavigationOnClickListener { parentFragmentManager.popBackStack() }
+        }
+    }
+
+    override fun bindView() {
+        arguments?.run {
+            val data: Collection? = getParcelable(ARGUMENT_COLLECTION)
+            viewModel.setCollection(data)
+        }
+        (viewBinding.recyclerCollectionPhoto.layoutManager as StaggeredGridLayoutManager).gapStrategy =
+            StaggeredGridLayoutManager.GAP_HANDLING_MOVE_ITEMS_BETWEEN_SPANS
+    }
+
+    override fun registerLiveData() = with(viewModel) {
+        super.registerLiveData()
+        collection.observe(viewLifecycleOwner, ::setCollectionData)
+        photos.observe(viewLifecycleOwner, ::updatePhotos)
+    }
+
+    private fun setCollectionData(collection: Collection) {
+        viewBinding.toolbarCollectionPhoto.title = collection.title
+        viewModel.getPhotosCollection(collection.id)
+    }
+
+    private fun clickPhotoItem(item: Photo) {
+        replaceFragment(R.id.containerFrameLayout, DetailFragment.newInstance(item))
+    }
+
+    private fun updatePhotos(photos: MutableList<Photo>) {
+        photoAdapter.updateData(photos)
+    }
+
+    companion object {
+        private const val ARGUMENT_COLLECTION = "ARGUMENT_COLLECTION"
+
+        fun newInstance(collection: Collection) = CollectionPhotoFragment().apply {
+            arguments = bundleOf(ARGUMENT_COLLECTION to collection)
+        }
+    }
+}

--- a/app/src/main/java/com/sun/unsplash03/screen/collection_photo/CollectionPhotoViewModel.kt
+++ b/app/src/main/java/com/sun/unsplash03/screen/collection_photo/CollectionPhotoViewModel.kt
@@ -1,0 +1,31 @@
+package com.sun.unsplash03.screen.collection_photo
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import com.sun.unsplash03.data.model.Collection
+import com.sun.unsplash03.data.model.Photo
+import com.sun.unsplash03.data.repository.PhotoRepository
+import com.sun.unsplash03.utils.base.BaseViewModel
+
+class CollectionPhotoViewModel(private val repository: PhotoRepository) : BaseViewModel() {
+
+    private val _collection = MutableLiveData<Collection>()
+    val collection: LiveData<Collection>
+        get() = _collection
+
+    private val _photos = MutableLiveData<MutableList<Photo>>()
+    val photos: LiveData<MutableList<Photo>>
+        get() = _photos
+
+    fun setCollection(data: Collection?) {
+        data?.let { _collection.value = it }
+    }
+
+    fun getPhotosCollection(collectionId: String) {
+        viewModelScope(
+            onRequest = {
+                repository.getCollectionPhotos(collectionId, null)
+            }, liveData = _photos
+        )
+    }
+}

--- a/app/src/main/java/com/sun/unsplash03/screen/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/sun/unsplash03/screen/detail/DetailViewModel.kt
@@ -12,8 +12,6 @@ class DetailViewModel : BaseViewModel() {
         get() = _photos
 
     fun setPhoto(data: Photo?) {
-        data?.let {
-            _photos.value = it
-        }
+        data?.let { _photos.value = it }
     }
 }

--- a/app/src/main/res/layout/fragment_collection_photo.xml
+++ b/app/src/main/res/layout/fragment_collection_photo.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <data>
+
+        <variable
+            name="viewModel"
+            type="com.sun.unsplash03.screen.collection_photo.CollectionPhotoViewModel" />
+
+        <variable
+            name="adapter"
+            type="com.sun.unsplash03.screen.photo.adapter.PhotoAdapter" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/toolbarCollectionPhoto"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:titleTextColor="@android:color/white"
+            android:background="@color/gray_500"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:navigationIcon="@drawable/ic_back" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recyclerCollectionPhoto"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:adapter="@{adapter}"
+            app:layoutManager="androidx.recyclerview.widget.StaggeredGridLayoutManager"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/toolbarCollectionPhoto"
+            app:spanCount="3" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>


### PR DESCRIPTION
## Related Tickets
- [#Task 37491: Xử lý khi người dùng click chọn collection](https://edu-redmine.sun-asterisk.vn/issues/37491)
## WHAT
- Xử lý khi người dùng click chọn collection
## Evidence (Screenshot or Video)
![Screenshot from 2021-06-25 13-04-05](https://user-images.githubusercontent.com/83062073/123391337-1e170c80-d5c6-11eb-8761-0a77501cbb43.png)
![Screenshot from 2021-06-25 13-04-20](https://user-images.githubusercontent.com/83062073/123391350-21aa9380-d5c6-11eb-884e-d7f57290468e.png)

## Review Checklist

Category | View Point | Description | Self review | Reviewer2 (name)
--- | --- | --- | --- | ---
Conventions | Sun* coding conventions | https://github.com/framgia/coding-standards/tree/master/eng/android |<li>- [ ] yes</li>|<li>- [ ] yes</li>
Conventions | Kotlin coding conventions | https://kotlinlang.org/docs/coding-conventions.html |<li>- [ ] yes</li>|<li>- [ ] yes</li>
Redmine | Sun* Redmine working process  | https://github.com/framgia/Training-Guideline/blob/master/WorkingProcess/redmine/redmine.md |<li>- [ ] yes</li>|<li>- [ ] yes</li>

## Notes (Optional)
*(Impacted Areas in Application(List features, api, models or services that this PR will affect))*

*(List gem, library third party add new)*

*(Other notes)*